### PR TITLE
feat(gateway): 支持 Streamable HTTP GET SSE 与 MCP Session（修复 Cursor 连接）

### DIFF
--- a/.changeset/streamable-http-get-sse.md
+++ b/.changeset/streamable-http-get-sse.md
@@ -1,0 +1,5 @@
+---
+"moor": minor
+---
+
+Gateway: add Streamable HTTP GET SSE streams and MCP session handling (`Mcp-Session-Id`, DELETE) so Cursor and other Streamable HTTP clients can connect after `initialize`

--- a/src-tauri/src/sidecar/http/mod.rs
+++ b/src-tauri/src/sidecar/http/mod.rs
@@ -3,6 +3,7 @@ mod auth;
 pub mod routes;
 
 use crate::sidecar::db::Database;
+use crate::sidecar::mcp::transport::mcp_session::McpSessionStore;
 use crate::sidecar::services::event_bus::EventBus;
 use crate::sidecar::services::server_manager::ServerManager;
 use axum::{http::StatusCode, middleware, response::IntoResponse, Json, Router};
@@ -15,6 +16,7 @@ pub struct AppState {
     pub api_token: String,
     pub version: String,
     pub port: u16,
+    pub mcp_sessions: Arc<McpSessionStore>,
     pub event_bus: Arc<EventBus>,
     pub server_manager: Arc<ServerManager>,
 }
@@ -34,6 +36,7 @@ impl AppState {
             api_token,
             version,
             port,
+            mcp_sessions: Arc::new(McpSessionStore::new()),
             event_bus,
             server_manager,
         }

--- a/src-tauri/src/sidecar/mcp/server.rs
+++ b/src-tauri/src/sidecar/mcp/server.rs
@@ -240,6 +240,9 @@ process.stdin.on("data", (chunk) => {
             api_token: "test-token".to_string(),
             version: "test".to_string(),
             port: 19323,
+            mcp_sessions: Arc::new(
+                crate::sidecar::mcp::transport::mcp_session::McpSessionStore::new(),
+            ),
             event_bus,
             server_manager,
         });

--- a/src-tauri/src/sidecar/mcp/transport/mcp_session.rs
+++ b/src-tauri/src/sidecar/mcp/transport/mcp_session.rs
@@ -1,0 +1,49 @@
+use std::collections::HashSet;
+use tokio::sync::RwLock;
+
+/// Tracks Streamable HTTP MCP sessions for GET SSE streams.
+pub struct McpSessionStore {
+    sessions: RwLock<HashSet<String>>,
+}
+
+impl McpSessionStore {
+    pub fn new() -> Self {
+        Self {
+            sessions: RwLock::new(HashSet::new()),
+        }
+    }
+
+    pub async fn create(&self) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        self.sessions.write().await.insert(id.clone());
+        id
+    }
+
+    pub async fn contains(&self, session_id: &str) -> bool {
+        self.sessions.read().await.contains(session_id)
+    }
+
+    pub async fn remove(&self, session_id: &str) -> bool {
+        self.sessions.write().await.remove(session_id)
+    }
+}
+
+impl Default for McpSessionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn create_contains_and_remove_session() {
+        let store = McpSessionStore::new();
+        let id = store.create().await;
+        assert!(store.contains(&id).await);
+        assert!(store.remove(&id).await);
+        assert!(!store.contains(&id).await);
+    }
+}

--- a/src-tauri/src/sidecar/mcp/transport/mod.rs
+++ b/src-tauri/src/sidecar/mcp/transport/mod.rs
@@ -1,5 +1,6 @@
 pub mod http_client;
 pub mod mcp_client;
+pub mod mcp_session;
 pub mod stdio_client;
 pub mod streamable_http_server;
 

--- a/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
+++ b/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
@@ -1,17 +1,99 @@
 use crate::sidecar::http::AppState;
+use crate::sidecar::mcp::jsonrpc;
 use axum::{
+    body::Body,
     extract::State,
-    http::{header, StatusCode},
-    response::{IntoResponse, Response},
+    http::{header, HeaderMap, Method, StatusCode},
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse, Response,
+    },
 };
-use std::sync::Arc;
+use futures::stream::{self, Stream};
+use std::{convert::Infallible, sync::Arc, time::Duration};
+
+const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
 
 /// Handle incoming MCP Streamable HTTP requests at `/mcp`.
-/// Supports both JSON responses and SSE streaming.
+/// Supports POST JSON-RPC, GET SSE streams, and DELETE session teardown.
 pub async fn handle_mcp_request(
     State(state): State<Arc<AppState>>,
     req: axum::extract::Request,
 ) -> Response {
+    match *req.method() {
+        Method::GET => handle_mcp_get(state, req.headers()).await,
+        Method::DELETE => handle_mcp_delete(state, req.headers()).await,
+        _ => handle_mcp_post(state, req).await,
+    }
+}
+
+async fn handle_mcp_get(state: Arc<AppState>, headers: &HeaderMap) -> Response {
+    let accept = headers
+        .get(header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if !accept.contains("text/event-stream") {
+        return (
+            StatusCode::NOT_ACCEPTABLE,
+            [(header::CONTENT_TYPE, "application/json")],
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": null,
+                "error": {
+                    "code": jsonrpc::INVALID_REQUEST,
+                    "message": "GET requires Accept: text/event-stream"
+                }
+            })
+            .to_string(),
+        )
+            .into_response();
+    }
+
+    let session_id = headers
+        .get(MCP_SESSION_ID_HEADER)
+        .and_then(|v| v.to_str().ok());
+
+    let Some(session_id) = session_id else {
+        return sse_keep_alive(stream::pending()).into_response();
+    };
+
+    if !state.mcp_sessions.contains(session_id).await {
+        return (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "application/json")],
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": null,
+                "error": {
+                    "code": jsonrpc::INVALID_REQUEST,
+                    "message": "Unknown MCP session"
+                }
+            })
+            .to_string(),
+        )
+            .into_response();
+    }
+
+    sse_keep_alive(stream::pending()).into_response()
+}
+
+async fn handle_mcp_delete(state: Arc<AppState>, headers: &HeaderMap) -> Response {
+    let Some(session_id) = headers
+        .get(MCP_SESSION_ID_HEADER)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+
+    if state.mcp_sessions.remove(session_id).await {
+        StatusCode::OK.into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
+}
+
+async fn handle_mcp_post(state: Arc<AppState>, req: axum::extract::Request) -> Response {
     let headers = req.headers().clone();
     let accept = headers
         .get(header::ACCEPT)
@@ -24,25 +106,32 @@ pub async fn handle_mcp_request(
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
 
-    // Read request body
     let body_bytes = match axum::body::to_bytes(req.into_body(), 1024 * 1024).await {
         Ok(b) => b,
         Err(_) => return (StatusCode::BAD_REQUEST, "Request body too large").into_response(),
     };
 
-    // Accept header determines response format.
+    if body_bytes.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            [(header::CONTENT_TYPE, "application/json")],
+            jsonrpc::make_error(jsonrpc::Id::Number(0), jsonrpc::PARSE_ERROR, "Invalid JSON-RPC")
+                .to_string(),
+        )
+            .into_response();
+    }
+
     let accepts_sse = accept.contains("text/event-stream");
 
-    // Parse JSON-RPC request
     let raw_message: serde_json::Value = match serde_json::from_slice(&body_bytes) {
         Ok(v) => v,
         Err(_) => {
             return (
                 StatusCode::BAD_REQUEST,
                 [(header::CONTENT_TYPE, "application/json")],
-                crate::sidecar::mcp::jsonrpc::make_error(
-                    crate::sidecar::mcp::jsonrpc::Id::Number(0),
-                    crate::sidecar::mcp::jsonrpc::PARSE_ERROR,
+                jsonrpc::make_error(
+                    jsonrpc::Id::Number(0),
+                    jsonrpc::PARSE_ERROR,
                     "Invalid JSON-RPC",
                 )
                 .to_string(),
@@ -50,18 +139,20 @@ pub async fn handle_mcp_request(
                 .into_response()
         }
     };
+
     if raw_message.get("id").is_none() {
         return StatusCode::ACCEPTED.into_response();
     }
-    let parsed = match crate::sidecar::mcp::jsonrpc::parse_request_value(&raw_message) {
+
+    let parsed = match jsonrpc::parse_request_value(&raw_message) {
         Some(p) => p,
         None => {
             return (
                 StatusCode::BAD_REQUEST,
                 [(header::CONTENT_TYPE, "application/json")],
-                crate::sidecar::mcp::jsonrpc::make_error(
-                    crate::sidecar::mcp::jsonrpc::Id::Number(0),
-                    crate::sidecar::mcp::jsonrpc::INVALID_REQUEST,
+                jsonrpc::make_error(
+                    jsonrpc::Id::Number(0),
+                    jsonrpc::INVALID_REQUEST,
                     "Invalid JSON-RPC request",
                 )
                 .to_string(),
@@ -71,8 +162,12 @@ pub async fn handle_mcp_request(
     };
 
     let (id, method, params) = parsed;
+    let new_session_id = if method == "initialize" {
+        Some(state.mcp_sessions.create().await)
+    } else {
+        None
+    };
 
-    // Route to MCP server handler
     let response = crate::sidecar::mcp::server::handle_request(
         id,
         &method,
@@ -82,24 +177,155 @@ pub async fn handle_mcp_request(
     )
     .await;
 
+    build_post_response(response, accepts_sse, new_session_id.as_deref())
+}
+
+fn build_post_response(
+    response: serde_json::Value,
+    accepts_sse: bool,
+    session_id: Option<&str>,
+) -> Response {
+    let mut builder = Response::builder();
+
+    if let Some(session_id) = session_id {
+        if let Ok(value) = header::HeaderValue::from_str(session_id) {
+            builder = builder.header(MCP_SESSION_ID_HEADER, value);
+        }
+    }
+
     if accepts_sse {
-        // Return as SSE event stream
         let sse_data = format!("event: message\ndata: {}\n\n", response);
-        (
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE, "text/event-stream"),
-                (header::CACHE_CONTROL, "no-cache"),
-            ],
-            sse_data,
-        )
-            .into_response()
+        builder
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .header(header::CACHE_CONTROL, "no-cache")
+            .body(Body::from(sse_data))
+            .unwrap()
     } else {
-        (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/json")],
-            response.to_string(),
-        )
-            .into_response()
+        builder
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(response.to_string()))
+            .unwrap()
+    }
+}
+
+fn sse_keep_alive<S>(stream: S) -> impl IntoResponse
+where
+    S: Stream<Item = Result<Event, Infallible>> + Send + 'static,
+{
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(30))
+            .text("keep-alive"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, Router};
+    use std::time::SystemTime;
+    use tower::ServiceExt;
+
+    fn temp_data_dir(test_name: &str) -> std::path::PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system time is before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("moor-mcp-http-{test_name}-{timestamp}"))
+    }
+
+    fn test_state(data_dir: std::path::PathBuf) -> Arc<AppState> {
+        AppState::for_test(&data_dir)
+    }
+
+    #[tokio::test]
+    async fn get_without_session_returns_sse_stream() {
+        let data_dir = temp_data_dir("get-sse");
+        let app = Router::new()
+            .route("/mcp", axum::routing::any(handle_mcp_request))
+            .with_state(test_state(data_dir.clone()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/mcp")
+                    .header(header::ACCEPT, "text/event-stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/event-stream"
+        );
+        let _ = std::fs::remove_dir_all(data_dir);
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_session_and_get_subscribes() {
+        let data_dir = temp_data_dir("session-flow");
+        let app = Router::new()
+            .route("/mcp", axum::routing::any(handle_mcp_request))
+            .with_state(test_state(data_dir.clone()));
+
+        let init_body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test", "version": "1.0" }
+            }
+        });
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::ACCEPT, "application/json")
+                    .body(Body::from(init_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .expect("initialize should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let session_id = response
+            .headers()
+            .get(MCP_SESSION_ID_HEADER)
+            .expect("initialize should return session id")
+            .to_str()
+            .expect("session id should be valid header")
+            .to_string();
+
+        let get_response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/mcp")
+                    .header(header::ACCEPT, "text/event-stream")
+                    .header(MCP_SESSION_ID_HEADER, session_id)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("get should succeed");
+
+        assert_eq!(get_response.status(), StatusCode::OK);
+        assert_eq!(
+            get_response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/event-stream"
+        );
+        let _ = std::fs::remove_dir_all(data_dir);
     }
 }


### PR DESCRIPTION
## 概述

按 @varandrew review 反馈重写本 PR：基于最新 `main`（v0.7.0）rebase，**移除**已与 `#60` / `allowLanMcpAccess` 重叠的 `allowWslMcpAccess`，**仅保留** Streamable HTTP 的 GET SSE 与 session 能力，修复 Cursor 等客户端在 `initialize` 后因 GET `/mcp` 返回 `400` 而无法连接的问题。

## 改动说明

### 已移除（main 已覆盖）

- `allowWslMcpAccess` 整条链路（bind / Host 校验 / settings / UI）
- LAN / WSL 访问请使用 Settings → Advanced → **Allow LAN MCP Access**（v0.7.0）

### 保留并适配到当前 main

| 能力 | 行为 |
|------|------|
| GET `/mcp` | 需 `Accept: text/event-stream`；无 session → keep-alive SSE；有效 `Mcp-Session-Id` → SSE；未知 session → `404` |
| POST `initialize` | 创建 session，响应头返回 `mcp-session-id` |
| DELETE `/mcp` | 清理 session（无 header → `400`；成功 → `200`；未知 → `404`） |
| 通知 | 无 `id` → `202 Accepted` |
| `McpSessionStore` | 内存 session 存储 + 单元测试 |

以上能力**无新开关**，对 loopback / LAN（在已开启 LAN 访问时）均生效。

## 安全

- 默认行为与 main 一致（loopback + Host 校验策略不变）
- `/api/*` 仍仅 loopback + `X-Moor-Token`
- `/mcp` 仍无需 token（设计不变）

## 测试计划

- [x] `cargo test --manifest-path src-tauri/Cargo.toml streamable_http_server`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml mcp_session`
- [ ] CI: `cargo test --manifest-path src-tauri/Cargo.toml`
- [ ] CI: `vp test`

## 关联

- 响应 #61 review；LAN 访问见 #60
- Session TTL / SSE 空闲超时见 #62（本 PR 不处理）
