### PR TITLE
fix(gateway): harden /mcp method dispatch

### DIFF
--- a/.changeset/streamable-http-get-sse.md
+++ b/.changeset/streamable-http-get-sse.md
@@ -2,4 +2,4 @@
 "moor": minor
 ---
 
-Gateway: add Streamable HTTP GET SSE streams and MCP session handling (`Mcp-Session-Id`, DELETE) so Cursor and other Streamable HTTP clients can connect after `initialize`
+Gateway: add Streamable HTTP GET SSE streams and MCP session handling (`Mcp-Session-Id`, DELETE) so Cursor and other Streamable HTTP clients can connect after `initialize` (thanks @835519608!)

--- a/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
+++ b/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
@@ -23,7 +23,8 @@ pub async fn handle_mcp_request(
     match *req.method() {
         Method::GET => handle_mcp_get(state, req.headers()).await,
         Method::DELETE => handle_mcp_delete(state, req.headers()).await,
-        _ => handle_mcp_post(state, req).await,
+        Method::POST => handle_mcp_post(state, req).await,
+        _ => StatusCode::METHOD_NOT_ALLOWED.into_response(),
     }
 }
 
@@ -54,8 +55,24 @@ async fn handle_mcp_get(state: Arc<AppState>, headers: &HeaderMap) -> Response {
         .get(MCP_SESSION_ID_HEADER)
         .and_then(|v| v.to_str().ok());
 
+    // Anonymous streams have no legitimate use: spec clients always send the
+    // session id obtained from initialize. Allowing them lets LAN clients open
+    // unlimited keep-alive streams.
     let Some(session_id) = session_id else {
-        return sse_keep_alive(stream::pending()).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            [(header::CONTENT_TYPE, "application/json")],
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": null,
+                "error": {
+                    "code": jsonrpc::INVALID_REQUEST,
+                    "message": "Missing Mcp-Session-Id header"
+                }
+            })
+            .to_string(),
+        )
+            .into_response();
     };
 
     if !state.mcp_sessions.contains(session_id).await {
@@ -115,8 +132,12 @@ async fn handle_mcp_post(state: Arc<AppState>, req: axum::extract::Request) -> R
         return (
             StatusCode::BAD_REQUEST,
             [(header::CONTENT_TYPE, "application/json")],
-            jsonrpc::make_error(jsonrpc::Id::Number(0), jsonrpc::PARSE_ERROR, "Invalid JSON-RPC")
-                .to_string(),
+            jsonrpc::make_error(
+                jsonrpc::Id::Number(0),
+                jsonrpc::PARSE_ERROR,
+                "Invalid JSON-RPC",
+            )
+            .to_string(),
         )
             .into_response();
     }
@@ -139,6 +160,18 @@ async fn handle_mcp_post(state: Arc<AppState>, req: axum::extract::Request) -> R
                 .into_response()
         }
     };
+
+    let method_name = raw_message.get("method").and_then(|m| m.as_str());
+    if method_name != Some("initialize") {
+        if let Some(session_id) = headers
+            .get(MCP_SESSION_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+        {
+            if !state.mcp_sessions.contains(session_id).await {
+                return StatusCode::NOT_FOUND.into_response();
+            }
+        }
+    }
 
     if raw_message.get("id").is_none() {
         return StatusCode::ACCEPTED.into_response();
@@ -241,8 +274,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_without_session_returns_sse_stream() {
+    async fn put_returns_method_not_allowed() {
         let data_dir = temp_data_dir("get-sse");
+        let app = Router::new()
+            .route("/mcp", axum::routing::any(handle_mcp_request))
+            .with_state(test_state(data_dir.clone()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::PUT)
+                    .uri("/mcp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        let _ = std::fs::remove_dir_all(data_dir);
+    }
+
+    #[tokio::test]
+    async fn get_without_session_returns_bad_request() {
+        let data_dir = temp_data_dir("get-no-session");
         let app = Router::new()
             .route("/mcp", axum::routing::any(handle_mcp_request))
             .with_state(test_state(data_dir.clone()));
@@ -259,11 +314,42 @@ mod tests {
             .await
             .expect("request should succeed");
 
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(
-            response.headers().get(header::CONTENT_TYPE).unwrap(),
-            "text/event-stream"
-        );
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should be readable");
+        assert!(String::from_utf8_lossy(&body).contains("Missing Mcp-Session-Id"));
+        let _ = std::fs::remove_dir_all(data_dir);
+    }
+
+    #[tokio::test]
+    async fn post_with_unknown_session_returns_not_found() {
+        let data_dir = temp_data_dir("post-unknown-session");
+        let app = Router::new()
+            .route("/mcp", axum::routing::any(handle_mcp_request))
+            .with_state(test_state(data_dir.clone()));
+
+        let request_body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list"
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::ACCEPT, "application/json")
+                    .header(MCP_SESSION_ID_HEADER, "forged-session-id")
+                    .body(Body::from(request_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
         let _ = std::fs::remove_dir_all(data_dir);
     }
 


### PR DESCRIPTION
Closes #63. Follow-up hardening to #61 (merged as f548056).

## Changes (`src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs`)

1. **GET without `Mcp-Session-Id` → 400** (was: anonymous infinite keep-alive stream). Spec clients always `initialize` first and send the session id, so anonymous streams have no legitimate use — but with `allowLanMcpAccess` enabled, any LAN client could open unlimited streams. Returns a JSON-RPC error, aligned with the TS SDK reference behavior ("Missing session ID"). If a real client regresses here, we can revisit.
2. **POST with unknown `Mcp-Session-Id` → 404** (spec: SHOULD). Validated right after JSON parse so notifications (id-less, 202 early return) are covered too. Requests without the header remain accepted — only *forged/unknown* ids are rejected.
3. **Unsupported methods → 405** (was: everything non-GET/DELETE fell into POST handling).

## Tests

- `get_without_session_returns_bad_request` (400 + error body)
- `post_with_unknown_session_returns_not_found` (404)
- `put_returns_method_not_allowed` (405)
- Full `cargo test --manifest-path src-tauri/Cargo.toml`: **108 passed, 0 failed**

Also adds credit to the unreleased changeset: *(thanks @835519608!)* so it lands in the release notes.

## Review notes

- GitNexus `impact` on `handle_mcp_request`/`handle_mcp_get`/`handle_mcp_post`: LOW risk, only caller is the dispatch itself.
- `detect_changes` flags CRITICAL because `/mcp` is the gateway entry point with 18 downstream cross-module flows (settings/audit/tool records) — changed symbols are exactly the intended five, no unexpected scope.