### PR TITLE
feat(gateway): MCP session idle TTL, capacity cap & SSE stream lifetime

### DIFF
--- a/.changeset/mcp-session-ttl.md
+++ b/.changeset/mcp-session-ttl.md
@@ -1,0 +1,11 @@
+---
+"moor": minor
+---
+
+feat(gateway): MCP session idle TTL, capacity cap & SSE stream lifetime
+
+- Sessions now expire after an idle TTL (new setting `advanced.mcpSessionIdleTtlMs`, default 1h, valid range 5min–24h); validation on POST/GET refreshes liveness and a 60s background sweeper reclaims sessions leaked by crashed clients.
+- `initialize` beyond 128 concurrent sessions returns HTTP 503 instead of growing unboundedly.
+- GET SSE keep-alive streams close after a 30min total lifetime; clients reconnect per the Streamable HTTP spec.
+
+Closes #62

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -4,6 +4,10 @@ export const MCP_TIMEOUT_MS_MIN = 5_000;
 export const MCP_TIMEOUT_MS_MAX = 300_000;
 export const MCP_TIMEOUT_MS_DEFAULT = 30_000;
 
+export const MCP_SESSION_IDLE_TTL_MS_MIN = 300_000;
+export const MCP_SESSION_IDLE_TTL_MS_MAX = 86_400_000;
+export const MCP_SESSION_IDLE_TTL_MS_DEFAULT = 3_600_000;
+
 export interface GeneralSettings {
   autoStartOnLogin: boolean;
   autoStartServersOnLaunch: boolean;
@@ -23,6 +27,7 @@ export interface AdvancedSettings {
   allowLanMcpAccess: boolean;
   mcpRequestTimeoutMs: number;
   mcpServerStartTimeoutMs: number;
+  mcpSessionIdleTtlMs: number;
 }
 
 export interface Settings {
@@ -58,6 +63,7 @@ export function createDefaultSettings(): Settings {
       allowLanMcpAccess: false,
       mcpRequestTimeoutMs: MCP_TIMEOUT_MS_DEFAULT,
       mcpServerStartTimeoutMs: MCP_TIMEOUT_MS_DEFAULT,
+      mcpSessionIdleTtlMs: MCP_SESSION_IDLE_TTL_MS_DEFAULT,
     },
   };
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,4 +48,5 @@ default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
 
 [dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }
 tower = { version = "0.5", features = ["util"] }

--- a/src-tauri/src/sidecar/http/mod.rs
+++ b/src-tauri/src/sidecar/http/mod.rs
@@ -102,6 +102,7 @@ pub fn json_error_response(
 }
 
 pub async fn start_server(state: Arc<AppState>, host: &str, port: u16) -> Result<(), String> {
+    crate::sidecar::mcp::transport::streamable_http_server::spawn_session_sweeper(state.clone());
     let addr = format!("{host}:{port}");
     let std_listener =
         crate::bind_listener(host, port).map_err(|e| format!("Failed to bind {addr}: {e}"))?;

--- a/src-tauri/src/sidecar/mcp/transport/mcp_session.rs
+++ b/src-tauri/src/sidecar/mcp/transport/mcp_session.rs
@@ -7,10 +7,6 @@ use tokio::time::Instant;
 /// client bug, so new sessions are rejected (503) instead of evicting.
 const MAX_SESSIONS: usize = 128;
 
-/// Fallback idle TTL when settings are unreadable; the live value comes from
-/// `advanced.mcpSessionIdleTtlMs`.
-pub const SESSION_IDLE_TTL_FALLBACK: Duration = Duration::from_secs(60 * 60);
-
 /// Tracks Streamable HTTP MCP sessions with idle-TTL expiry.
 pub struct McpSessionStore {
     sessions: RwLock<HashMap<String, Instant>>,
@@ -79,19 +75,21 @@ impl Default for McpSessionStore {
 mod tests {
     use super::*;
 
+    const TEST_TTL: Duration = Duration::from_secs(60 * 60);
+
     #[tokio::test]
     async fn create_validate_and_remove_session() {
         let store = McpSessionStore::new();
         let id = store.create().await.expect("session created");
         assert!(
             store
-                .validate_and_touch(&id, SESSION_IDLE_TTL_FALLBACK)
+                .validate_and_touch(&id, TEST_TTL)
                 .await
         );
         assert!(store.remove(&id).await);
         assert!(
             !store
-                .validate_and_touch(&id, SESSION_IDLE_TTL_FALLBACK)
+                .validate_and_touch(&id, TEST_TTL)
                 .await
         );
     }
@@ -100,10 +98,10 @@ mod tests {
     async fn expired_session_fails_validation_and_is_dropped() {
         let store = McpSessionStore::new();
         let id = store.create().await.expect("session created");
-        tokio::time::advance(SESSION_IDLE_TTL_FALLBACK + Duration::from_secs(1)).await;
+        tokio::time::advance(TEST_TTL + Duration::from_secs(1)).await;
         assert!(
             !store
-                .validate_and_touch(&id, SESSION_IDLE_TTL_FALLBACK)
+                .validate_and_touch(&id, TEST_TTL)
                 .await
         );
         assert_eq!(store.len().await, 0);
@@ -117,7 +115,7 @@ mod tests {
             .create()
             .await
             .expect("second session created");
-        tokio::time::advance(SESSION_IDLE_TTL_FALLBACK + Duration::from_secs(1)).await;
+        tokio::time::advance(TEST_TTL + Duration::from_secs(1)).await;
         // Refresh the second session so only the first one is idle.
         let mut sessions = store.sessions.write().await;
         let keys: Vec<String> = sessions.keys().cloned().collect();
@@ -128,7 +126,7 @@ mod tests {
         }
         drop(sessions);
 
-        assert_eq!(store.sweep_expired(SESSION_IDLE_TTL_FALLBACK).await, 1);
+        assert_eq!(store.sweep_expired(TEST_TTL).await, 1);
         assert_eq!(store.len().await, 1);
     }
 

--- a/src-tauri/src/sidecar/mcp/transport/mcp_session.rs
+++ b/src-tauri/src/sidecar/mcp/transport/mcp_session.rs
@@ -1,30 +1,71 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
+use std::time::Duration;
 use tokio::sync::RwLock;
+use tokio::time::Instant;
 
-/// Tracks Streamable HTTP MCP sessions for GET SSE streams.
+/// Safety cap for a local single-user gateway; hitting it signals a leak or
+/// client bug, so new sessions are rejected (503) instead of evicting.
+const MAX_SESSIONS: usize = 128;
+
+/// Fallback idle TTL when settings are unreadable; the live value comes from
+/// `advanced.mcpSessionIdleTtlMs`.
+pub const SESSION_IDLE_TTL_FALLBACK: Duration = Duration::from_secs(60 * 60);
+
+/// Tracks Streamable HTTP MCP sessions with idle-TTL expiry.
 pub struct McpSessionStore {
-    sessions: RwLock<HashSet<String>>,
+    sessions: RwLock<HashMap<String, Instant>>,
 }
 
 impl McpSessionStore {
     pub fn new() -> Self {
         Self {
-            sessions: RwLock::new(HashSet::new()),
+            sessions: RwLock::new(HashMap::new()),
         }
     }
 
-    pub async fn create(&self) -> String {
+    /// Creates a session; `None` means the store is at capacity.
+    pub async fn create(&self) -> Option<String> {
+        let mut sessions = self.sessions.write().await;
+        if sessions.len() >= MAX_SESSIONS {
+            return None;
+        }
         let id = uuid::Uuid::new_v4().to_string();
-        self.sessions.write().await.insert(id.clone());
-        id
+        sessions.insert(id.clone(), Instant::now());
+        Some(id)
     }
 
-    pub async fn contains(&self, session_id: &str) -> bool {
-        self.sessions.read().await.contains(session_id)
+    /// Returns true (refreshing liveness) when the session exists and has been
+    /// idle for less than `ttl`; expired entries are dropped on sight.
+    pub async fn validate_and_touch(&self, session_id: &str, ttl: Duration) -> bool {
+        let mut sessions = self.sessions.write().await;
+        match sessions.get_mut(session_id) {
+            Some(last_active) if last_active.elapsed() <= ttl => {
+                *last_active = Instant::now();
+                true
+            }
+            Some(_) => {
+                sessions.remove(session_id);
+                false
+            }
+            None => false,
+        }
     }
 
     pub async fn remove(&self, session_id: &str) -> bool {
-        self.sessions.write().await.remove(session_id)
+        self.sessions.write().await.remove(session_id).is_some()
+    }
+
+    /// Drops sessions idle beyond `ttl`; returns how many were removed.
+    pub async fn sweep_expired(&self, ttl: Duration) -> usize {
+        let mut sessions = self.sessions.write().await;
+        let before = sessions.len();
+        sessions.retain(|_, last_active| last_active.elapsed() <= ttl);
+        before - sessions.len()
+    }
+
+    #[cfg(test)]
+    pub async fn len(&self) -> usize {
+        self.sessions.read().await.len()
     }
 }
 
@@ -39,11 +80,68 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn create_contains_and_remove_session() {
+    async fn create_validate_and_remove_session() {
         let store = McpSessionStore::new();
-        let id = store.create().await;
-        assert!(store.contains(&id).await);
+        let id = store.create().await.expect("session created");
+        assert!(
+            store
+                .validate_and_touch(&id, SESSION_IDLE_TTL_FALLBACK)
+                .await
+        );
         assert!(store.remove(&id).await);
-        assert!(!store.contains(&id).await);
+        assert!(
+            !store
+                .validate_and_touch(&id, SESSION_IDLE_TTL_FALLBACK)
+                .await
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expired_session_fails_validation_and_is_dropped() {
+        let store = McpSessionStore::new();
+        let id = store.create().await.expect("session created");
+        tokio::time::advance(SESSION_IDLE_TTL_FALLBACK + Duration::from_secs(1)).await;
+        assert!(
+            !store
+                .validate_and_touch(&id, SESSION_IDLE_TTL_FALLBACK)
+                .await
+        );
+        assert_eq!(store.len().await, 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sweep_expired_removes_only_idle_sessions() {
+        let store = McpSessionStore::new();
+        let idle = store.create().await.expect("session created");
+        store
+            .create()
+            .await
+            .expect("second session created");
+        tokio::time::advance(SESSION_IDLE_TTL_FALLBACK + Duration::from_secs(1)).await;
+        // Refresh the second session so only the first one is idle.
+        let mut sessions = store.sessions.write().await;
+        let keys: Vec<String> = sessions.keys().cloned().collect();
+        for key in keys {
+            if key != idle {
+                sessions.insert(key, Instant::now());
+            }
+        }
+        drop(sessions);
+
+        assert_eq!(store.sweep_expired(SESSION_IDLE_TTL_FALLBACK).await, 1);
+        assert_eq!(store.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn create_returns_none_at_capacity() {
+        let store = McpSessionStore::new();
+        for _ in 0..MAX_SESSIONS {
+            store
+                .create()
+                .await
+                .expect("sessions below capacity should be created");
+        }
+        assert!(store.create().await.is_none());
+        assert_eq!(store.len().await, MAX_SESSIONS);
     }
 }

--- a/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
+++ b/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
@@ -1,5 +1,4 @@
 use crate::sidecar::http::AppState;
-use crate::sidecar::mcp::transport::mcp_session::SESSION_IDLE_TTL_FALLBACK;
 use crate::sidecar::mcp::jsonrpc;
 use axum::{
     body::Body,
@@ -276,9 +275,14 @@ fn build_post_response(
     }
 }
 
-/// Idle TTL used for session expiry checks (validate + sweep paths).
-async fn session_idle_ttl(_state: &AppState) -> Duration {
-    SESSION_IDLE_TTL_FALLBACK
+/// Live session idle TTL from settings; falls back to the default when the
+/// settings store is unreadable, so expiry checks never panic.
+async fn session_idle_ttl(state: &AppState) -> Duration {
+    crate::sidecar::services::settings::get_settings(state.db.as_ref())
+        .map(|settings| Duration::from_millis(settings.advanced.mcp_session_idle_ttl_ms as u64))
+        .unwrap_or(Duration::from_millis(
+            crate::sidecar::services::settings::MCP_SESSION_IDLE_TTL_MS_DEFAULT as u64,
+        ))
 }
 
 /// Periodically drops idle sessions so crashed clients don't leak entries.

--- a/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
+++ b/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
@@ -1,4 +1,5 @@
 use crate::sidecar::http::AppState;
+use crate::sidecar::mcp::transport::mcp_session::SESSION_IDLE_TTL_FALLBACK;
 use crate::sidecar::mcp::jsonrpc;
 use axum::{
     body::Body,
@@ -75,7 +76,11 @@ async fn handle_mcp_get(state: Arc<AppState>, headers: &HeaderMap) -> Response {
             .into_response();
     };
 
-    if !state.mcp_sessions.contains(session_id).await {
+    if !state
+        .mcp_sessions
+        .validate_and_touch(session_id, session_idle_ttl(&state).await)
+        .await
+    {
         return (
             StatusCode::NOT_FOUND,
             [(header::CONTENT_TYPE, "application/json")],
@@ -167,7 +172,11 @@ async fn handle_mcp_post(state: Arc<AppState>, req: axum::extract::Request) -> R
             .get(MCP_SESSION_ID_HEADER)
             .and_then(|v| v.to_str().ok())
         {
-            if !state.mcp_sessions.contains(session_id).await {
+            if !state
+                .mcp_sessions
+                .validate_and_touch(session_id, session_idle_ttl(&state).await)
+                .await
+            {
                 return StatusCode::NOT_FOUND.into_response();
             }
         }
@@ -196,7 +205,22 @@ async fn handle_mcp_post(state: Arc<AppState>, req: axum::extract::Request) -> R
 
     let (id, method, params) = parsed;
     let new_session_id = if method == "initialize" {
-        Some(state.mcp_sessions.create().await)
+        match state.mcp_sessions.create().await {
+            Some(id) => Some(id),
+            None => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    [(header::CONTENT_TYPE, "application/json")],
+                    jsonrpc::make_error(
+                        id,
+                        jsonrpc::INTERNAL_ERROR,
+                        "MCP session capacity reached"
+                    )
+                    .to_string(),
+                )
+                    .into_response();
+            }
+        }
     } else {
         None
     };
@@ -241,6 +265,23 @@ fn build_post_response(
             .body(Body::from(response.to_string()))
             .unwrap()
     }
+}
+
+/// Idle TTL used for session expiry checks (validate + sweep paths).
+async fn session_idle_ttl(_state: &AppState) -> Duration {
+    SESSION_IDLE_TTL_FALLBACK
+}
+
+/// Periodically drops idle sessions so crashed clients don't leak entries.
+pub fn spawn_session_sweeper(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            let ttl = session_idle_ttl(&state).await;
+            state.mcp_sessions.sweep_expired(ttl).await;
+        }
+    });
 }
 
 fn sse_keep_alive<S>(stream: S) -> impl IntoResponse

--- a/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
+++ b/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
@@ -468,4 +468,153 @@ mod tests {
         );
         let _ = std::fs::remove_dir_all(data_dir);
     }
+
+    fn initialize_request_body() -> String {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test", "version": "1.0" }
+            }
+        })
+        .to_string()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn post_after_idle_ttl_returns_not_found() {
+        let data_dir = temp_data_dir("ttl-expiry");
+        let state = test_state(data_dir.clone());
+        let app = Router::new()
+            .route("/mcp", axum::routing::any(handle_mcp_request))
+            .with_state(state.clone());
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::ACCEPT, "application/json")
+                    .body(Body::from(initialize_request_body()))
+                    .unwrap(),
+            )
+            .await
+            .expect("initialize should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+        let session_id = response
+            .headers()
+            .get(MCP_SESSION_ID_HEADER)
+            .expect("initialize should return session id")
+            .to_str()
+            .expect("session id should be valid header")
+            .to_string();
+
+        let ttl = crate::sidecar::services::settings::get_settings(state.db.as_ref())
+            .expect("settings should be readable")
+            .advanced
+            .mcp_session_idle_ttl_ms;
+        tokio::time::advance(Duration::from_millis(ttl as u64) + Duration::from_secs(1)).await;
+
+        let expired = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::ACCEPT, "application/json")
+                    .header(MCP_SESSION_ID_HEADER, session_id)
+                    .body(Body::from(
+                        serde_json::json!({
+                            "jsonrpc": "2.0", "id": 2, "method": "tools/list"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(expired.status(), StatusCode::NOT_FOUND);
+        let _ = std::fs::remove_dir_all(data_dir);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn get_stream_ends_after_max_lifetime() {
+        let data_dir = temp_data_dir("sse-lifetime");
+        let app = Router::new()
+            .route("/mcp", axum::routing::any(handle_mcp_request))
+            .with_state(test_state(data_dir.clone()));
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::ACCEPT, "application/json")
+                    .body(Body::from(initialize_request_body()))
+                    .unwrap(),
+            )
+            .await
+            .expect("initialize should succeed");
+        let session_id = response
+            .headers()
+            .get(MCP_SESSION_ID_HEADER)
+            .expect("initialize should return session id")
+            .to_str()
+            .expect("session id should be valid header")
+            .to_string();
+
+        let get_response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/mcp")
+                    .header(header::ACCEPT, "text/event-stream")
+                    .header(MCP_SESSION_ID_HEADER, session_id)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("get should succeed");
+        assert_eq!(get_response.status(), StatusCode::OK);
+
+        // Paused time auto-advances while the body task waits on timers, so
+        // consuming the body drives the stream to its lifetime bound.
+        let bytes = axum::body::to_bytes(get_response.into_body(), usize::MAX)
+            .await
+            .expect("stream should end gracefully at max lifetime");
+        let body = String::from_utf8_lossy(&bytes);
+        assert!(body.contains("keep-alive"));
+        let _ = std::fs::remove_dir_all(data_dir);
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_503_at_session_capacity() {
+        let data_dir = temp_data_dir("session-capacity");
+        let state = test_state(data_dir.clone());
+        while state.mcp_sessions.create().await.is_some() {}
+
+        let app = Router::new()
+            .route("/mcp", axum::routing::any(handle_mcp_request))
+            .with_state(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::ACCEPT, "application/json")
+                    .body(Body::from(initialize_request_body()))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let _ = std::fs::remove_dir_all(data_dir);
+    }
 }

--- a/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
+++ b/src-tauri/src/sidecar/mcp/transport/streamable_http_server.rs
@@ -11,9 +11,14 @@ use axum::{
     },
 };
 use futures::stream::{self, Stream};
+use futures::StreamExt;
 use std::{convert::Infallible, sync::Arc, time::Duration};
 
 const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
+
+/// Total GET SSE stream lifetime; the server closes the stream afterwards and
+/// clients are expected to reconnect (MCP Streamable HTTP spec).
+const SSE_STREAM_MAX_LIFETIME: Duration = Duration::from_secs(30 * 60);
 
 /// Handle incoming MCP Streamable HTTP requests at `/mcp`.
 /// Supports POST JSON-RPC, GET SSE streams, and DELETE session teardown.
@@ -97,7 +102,11 @@ async fn handle_mcp_get(state: Arc<AppState>, headers: &HeaderMap) -> Response {
             .into_response();
     }
 
-    sse_keep_alive(stream::pending()).into_response()
+    // The stream carries no real events today (placeholder keep-alive only),
+    // so ending it at a fixed lifetime loses nothing; clients reconnect per spec.
+    let bounded = stream::pending::<Result<Event, Infallible>>()
+        .take_until(tokio::time::sleep(SSE_STREAM_MAX_LIFETIME));
+    sse_keep_alive(bounded).into_response()
 }
 
 async fn handle_mcp_delete(state: Arc<AppState>, headers: &HeaderMap) -> Response {

--- a/src-tauri/src/sidecar/services/settings.rs
+++ b/src-tauri/src/sidecar/services/settings.rs
@@ -7,6 +7,9 @@ const SETTINGS_FILE: &str = "settings.json";
 pub const MCP_TIMEOUT_MS_MIN: u32 = 5_000;
 pub const MCP_TIMEOUT_MS_MAX: u32 = 300_000;
 pub const MCP_TIMEOUT_MS_DEFAULT: u32 = 30_000;
+pub const MCP_SESSION_IDLE_TTL_MS_MIN: u32 = 300_000;
+pub const MCP_SESSION_IDLE_TTL_MS_MAX: u32 = 86_400_000;
+pub const MCP_SESSION_IDLE_TTL_MS_DEFAULT: u32 = 3_600_000;
 
 /// Distinguishes client input errors (HTTP 400) from internal failures (HTTP 500).
 #[derive(Debug)]
@@ -48,6 +51,7 @@ pub struct AdvancedSettings {
     pub allow_lan_mcp_access: bool,
     pub mcp_request_timeout_ms: u32,
     pub mcp_server_start_timeout_ms: u32,
+    pub mcp_session_idle_ttl_ms: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -84,6 +88,7 @@ struct PartialAdvancedSettings {
     allow_lan_mcp_access: Option<bool>,
     mcp_request_timeout_ms: Option<u32>,
     mcp_server_start_timeout_ms: Option<u32>,
+    mcp_session_idle_ttl_ms: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -115,6 +120,7 @@ pub fn default_settings() -> Settings {
             allow_lan_mcp_access: false,
             mcp_request_timeout_ms: MCP_TIMEOUT_MS_DEFAULT,
             mcp_server_start_timeout_ms: MCP_TIMEOUT_MS_DEFAULT,
+            mcp_session_idle_ttl_ms: MCP_SESSION_IDLE_TTL_MS_DEFAULT,
         },
     }
 }
@@ -193,6 +199,11 @@ fn settings_to_db_entries(settings: &Settings) -> Result<Vec<(&'static str, Stri
         (
             "advanced.mcpServerStartTimeoutMs",
             serde_json::to_string(&settings.advanced.mcp_server_start_timeout_ms)
+                .map_err(|e| e.to_string())?,
+        ),
+        (
+            "advanced.mcpSessionIdleTtlMs",
+            serde_json::to_string(&settings.advanced.mcp_session_idle_ttl_ms)
                 .map_err(|e| e.to_string())?,
         ),
     ])
@@ -317,6 +328,9 @@ pub fn merge_settings_value(mut base: Settings, value: Value) -> Result<Settings
         if let Some(value) = advanced.mcp_server_start_timeout_ms {
             base.advanced.mcp_server_start_timeout_ms = value;
         }
+        if let Some(value) = advanced.mcp_session_idle_ttl_ms {
+            base.advanced.mcp_session_idle_ttl_ms = value;
+        }
     }
     validate_settings(&base)?;
     Ok(base)
@@ -350,6 +364,13 @@ fn validate_settings(settings: &Settings) -> Result<(), String> {
     {
         return Err(format!(
             "advanced.mcpServerStartTimeoutMs must be between {MCP_TIMEOUT_MS_MIN} and {MCP_TIMEOUT_MS_MAX}"
+        ));
+    }
+    if settings.advanced.mcp_session_idle_ttl_ms < MCP_SESSION_IDLE_TTL_MS_MIN
+        || settings.advanced.mcp_session_idle_ttl_ms > MCP_SESSION_IDLE_TTL_MS_MAX
+    {
+        return Err(format!(
+            "advanced.mcpSessionIdleTtlMs must be between {MCP_SESSION_IDLE_TTL_MS_MIN} and {MCP_SESSION_IDLE_TTL_MS_MAX}"
         ));
     }
     Ok(())

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -18,6 +18,7 @@ import {
   getGeneralSettingRuntimeAction,
   getPortBannerState,
   getSettingsPageLoadState,
+  parseIdleTtlSecondsInput,
   parseTimeoutSecondsInput,
 } from "./settings-state";
 
@@ -245,11 +246,16 @@ function AdvancedSection({
   const [localStartTimeout, setLocalStartTimeout] = useState(
     String(settings.advanced.mcpServerStartTimeoutMs / 1000),
   );
+  const [localSessionIdleTtl, setLocalSessionIdleTtl] = useState(
+    String(settings.advanced.mcpSessionIdleTtlMs / 1000),
+  );
   const [tokenVisible, setTokenVisible] = useState(false);
   const requestTimeoutState = parseTimeoutSecondsInput(localRequestTimeout);
   const startTimeoutState = parseTimeoutSecondsInput(localStartTimeout);
+  const sessionIdleTtlState = parseIdleTtlSecondsInput(localSessionIdleTtl);
   const requestTimeoutErrorId = "request-timeout-error";
   const startTimeoutErrorId = "server-start-timeout-error";
+  const sessionIdleTtlErrorId = "session-idle-ttl-error";
   const portStatus = getAdvancedPortStatus({
     runtimeInfo,
     configuredPort: settings.advanced.sidecarPort,
@@ -260,11 +266,13 @@ function AdvancedSection({
     setLocalPort(String(settings.advanced.sidecarPort));
     setLocalRequestTimeout(String(settings.advanced.mcpRequestTimeoutMs / 1000));
     setLocalStartTimeout(String(settings.advanced.mcpServerStartTimeoutMs / 1000));
+    setLocalSessionIdleTtl(String(settings.advanced.mcpSessionIdleTtlMs / 1000));
   }, [
     settings.advanced.logRetentionDays,
     settings.advanced.sidecarPort,
     settings.advanced.mcpRequestTimeoutMs,
     settings.advanced.mcpServerStartTimeoutMs,
+    settings.advanced.mcpSessionIdleTtlMs,
   ]);
 
   const applyRetention = async () => {
@@ -297,7 +305,7 @@ function AdvancedSection({
     }
   };
 
-  type TimeoutKey = "mcpRequestTimeoutMs" | "mcpServerStartTimeoutMs";
+  type TimeoutKey = "mcpRequestTimeoutMs" | "mcpServerStartTimeoutMs" | "mcpSessionIdleTtlMs";
 
   const applyTimeout = async (
     key: TimeoutKey,
@@ -423,6 +431,45 @@ function AdvancedSection({
               {!startTimeoutState.valid && (
                 <p id={startTimeoutErrorId} className="font-body text-[11px] text-error-warm">
                   {startTimeoutState.message}
+                </p>
+              )}
+            </div>
+          </SettingRow>
+          <SettingRow
+            label="Session Idle TTL"
+            description="Idle expiry for MCP sessions in seconds (300-86400). Idle clients re-initialize on their next request."
+          >
+            <div className="flex flex-col items-end gap-1">
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  min={300}
+                  max={86400}
+                  step={1}
+                  value={localSessionIdleTtl}
+                  aria-invalid={!sessionIdleTtlState.valid}
+                  aria-describedby={sessionIdleTtlState.valid ? undefined : sessionIdleTtlErrorId}
+                  onChange={(e) => setLocalSessionIdleTtl(e.target.value)}
+                  className="w-20 h-8 text-center text-xs"
+                />
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={!sessionIdleTtlState.valid}
+                  onClick={() =>
+                    void applyTimeout(
+                      "mcpSessionIdleTtlMs",
+                      sessionIdleTtlState,
+                      "session idle TTL",
+                    )
+                  }
+                >
+                  Apply
+                </Button>
+              </div>
+              {!sessionIdleTtlState.valid && (
+                <p id={sessionIdleTtlErrorId} className="font-body text-[11px] text-error-warm">
+                  {sessionIdleTtlState.message}
                 </p>
               )}
             </div>

--- a/src/pages/settings-state.ts
+++ b/src/pages/settings-state.ts
@@ -1,6 +1,8 @@
 import {
   MCP_TIMEOUT_MS_MAX,
   MCP_TIMEOUT_MS_MIN,
+  MCP_SESSION_IDLE_TTL_MS_MAX,
+  MCP_SESSION_IDLE_TTL_MS_MIN,
   type GeneralSettings,
   type SidecarInfo,
 } from "@moor/types";
@@ -22,7 +24,28 @@ export type TimeoutSecondsInputState =
 
 const timeoutSecondsMin = MCP_TIMEOUT_MS_MIN / 1000;
 const timeoutSecondsMax = MCP_TIMEOUT_MS_MAX / 1000;
-const timeoutInputError = `Enter a whole number between ${timeoutSecondsMin} and ${timeoutSecondsMax}.`;
+const idleTtlSecondsMin = MCP_SESSION_IDLE_TTL_MS_MIN / 1000;
+const idleTtlSecondsMax = MCP_SESSION_IDLE_TTL_MS_MAX / 1000;
+
+function parseBoundedSecondsInput(
+  value: string,
+  secondsMin: number,
+  secondsMax: number,
+): TimeoutSecondsInputState {
+  const error = `Enter a whole number between ${secondsMin} and ${secondsMax}.`;
+  if (!/^\d+$/.test(value.trim())) {
+    return { valid: false, message: error };
+  }
+  const seconds = Number(value);
+  if (seconds < secondsMin || seconds > secondsMax) {
+    return { valid: false, message: error };
+  }
+  return { valid: true, milliseconds: seconds * 1000 };
+}
+
+export function parseIdleTtlSecondsInput(value: string): TimeoutSecondsInputState {
+  return parseBoundedSecondsInput(value, idleTtlSecondsMin, idleTtlSecondsMax);
+}
 
 export function getSettingsPageLoadState({
   isLoading,
@@ -87,12 +110,5 @@ export function getGeneralSettingRuntimeAction(
 }
 
 export function parseTimeoutSecondsInput(value: string): TimeoutSecondsInputState {
-  if (!/^\d+$/.test(value.trim())) {
-    return { valid: false, message: timeoutInputError };
-  }
-  const seconds = Number(value);
-  if (seconds < timeoutSecondsMin || seconds > timeoutSecondsMax) {
-    return { valid: false, message: timeoutInputError };
-  }
-  return { valid: true, milliseconds: seconds * 1000 };
+  return parseBoundedSecondsInput(value, timeoutSecondsMin, timeoutSecondsMax);
 }


### PR DESCRIPTION
Closes #62

Implements the design shared in https://github.com/varandrew/moor/issues/62#issuecomment-5327309408.

## What

- **Session idle TTL** — `McpSessionStore` now maps session id → last-active `Instant`. POST (after session validation) and GET stream connects refresh liveness; expired entries are dropped on sight and a 60s background sweeper reclaims sessions leaked by crashed or reconnecting clients. TTL comes from the new setting `advanced.mcpSessionIdleTtlMs` (default 1h, valid 5min–24h), read live so changes apply without restart.
- **Capacity cap** — `initialize` beyond 128 concurrent sessions returns HTTP 503 (reject, not evict: hitting the cap signals a leak or client bug).
- **GET SSE stream lifetime** — the placeholder keep-alive stream now ends after a 30min total lifetime (`take_until`); clients reconnect per the Streamable HTTP spec. The 30s keep-alive ping is unchanged.

## Settings pipeline

New field flows through `settings.rs` (validation + persistence), `@moor/types`, and the Advanced settings UI (seconds input, same Apply pattern as the existing timeouts).

## Testing

- `cargo test` 114/114 (store unit tests + 3 new integration tests using `tokio` paused-clock: TTL expiry → 404, SSE graceful end at lifetime bound, 503 at capacity)
- `vp test` 66/66, `vp check` clean

Design trade-off note: a long-lived GET stream does **not** keep its session alive (liveness is request-driven); an idle client re-initializes transparently after TTL expiry.